### PR TITLE
Added cross-references

### DIFF
--- a/src/example_fgen_basic/error_v/creation.f90
+++ b/src/example_fgen_basic/error_v/creation.f90
@@ -16,7 +16,7 @@ contains
     function create_error(inv) result(err)
         !! Create an error
         !!
-        !! If an odd number is supplied, the error code is no error (TODO: cross-ref).
+        !! If an odd number is supplied, the error code is no error [[m_error_v:NO_ERROR_CODE(variable)]].
         !! If an even number is supplied, the error code is 1.
         !! If a negative number is supplied, the error code is 2.
 
@@ -42,7 +42,7 @@ contains
     function create_errors(invs, n) result(errs)
         !! Create a number of errors
         !!
-        !! If an odd number is supplied, the error code is no error (TODO: cross-ref).
+        !! If an odd number is supplied, the error code is no error [[m_error_v:NO_ERROR_CODE(variable)]].
         !! If an even number is supplied, the error code is 1.
         !! If a negative number is supplied, the error code is 2.
 

--- a/src/example_fgen_basic/error_v/creation.py
+++ b/src/example_fgen_basic/error_v/creation.py
@@ -1,5 +1,5 @@
 """
-Wrappers of `m_error_v_creation` [TODO think about naming and x-referencing]
+Wrappers of [`m_error_v_creation`](/fortran-api/module/m_error_v_creation.html)
 
 At the moment, all written by hand.
 We will auto-generate this in future.

--- a/src/example_fgen_basic/error_v/creation_wrapper.f90
+++ b/src/example_fgen_basic/error_v/creation_wrapper.f90
@@ -25,13 +25,12 @@ module m_error_v_creation_w
 contains
 
     function create_error(inv) result(res_instance_index)
-        !! Wrapper around `m_error_v_creation.create_error` (TODO: x-ref)
+        !> Wrapper around `m_error_v_creation.create_error` ([[m_error_v_creation(module):create_error(function)]])
 
         integer, intent(in) :: inv
         !! Input value to use to create the error
         !!
-        !! See docstring of `m_error_v_creation.create_error` for details.
-        !! [TODO: x-ref]
+        !> See docstring of [[m_error_v_creation(module):create_error(function)]] for details.
 
         integer :: res_instance_index
         !! Instance index of the result
@@ -56,13 +55,12 @@ contains
     end function create_error
 
     function create_errors(invs, n) result(res_instance_indexes)
-        !! Wrapper around `m_error_v_creation.create_errors` (TODO: x-ref)
+        !> Wrapper around `m_error_v_creation.create_errors` ([[m_error_v_creation(module):create_errors(function)]])
 
         integer, dimension(n), intent(in) :: invs
         !! Input value to use to create the error
         !!
-        !! See docstring of `m_error_v_creation.create_error` for details.
-        !! [TODO: x-ref]
+        !> See docstring of [[m_error_v_creation(module):create_errors(function)]] for details.
 
         integer, intent(in) :: n
         !! Number of values to create

--- a/src/example_fgen_basic/error_v/error_v.f90
+++ b/src/example_fgen_basic/error_v/error_v.f90
@@ -41,14 +41,14 @@ module m_error_v
     end type ErrorV
 
     interface ErrorV
-    !! Constructor interface - see build (TODO: figure out cross-ref syntax) for details
+    !> Constructor interface - see docs [[m_error_v(module):build(subroutine)]] of for details.
         module procedure :: constructor
     end interface ErrorV
 
 contains
 
+    !> Constructor function: see docs of [[m_error_v(module):build(procedure)]] for details.
     function constructor(code, message) result(self)
-        !! Constructor - see build (TODO: figure out cross-ref syntax) for details
 
         integer, intent(in) :: code
         character(len=*), optional, intent(in) :: message
@@ -68,7 +68,7 @@ contains
         integer, intent(in) :: code
         !! Error code
         !!
-        !! Use [TODO: figure out xref] `NO_ERROR_CODE` if there is no error
+        !> Use [[m_error_v:NO_ERROR_CODE(variable)]] if there is no error.
 
         character(len=*), optional, intent(in) :: message
         !! Error message

--- a/src/example_fgen_basic/error_v/error_v.py
+++ b/src/example_fgen_basic/error_v/error_v.py
@@ -1,5 +1,5 @@
 """
-Python equivalent of the Fortran `ErrorV` class [TODO: x-refs]
+Python equivalent of the Fortran [ErrorV](/fortran-api/type/errorv.html) class.
 
 At the moment, all written by hand.
 We will auto-generate this in future.

--- a/src/example_fgen_basic/error_v/error_v_manager.f90
+++ b/src/example_fgen_basic/error_v/error_v_manager.f90
@@ -1,4 +1,4 @@
-!> Manager of `ErrorV` (TODO: xref) across the Fortran-Python interface
+!> Manager of [[m_error_v(module)]] across the Fortran-Python interface
 !>
 !> Written by hand here.
 !> Generation to be automated in future (including docstrings of some sort).

--- a/src/example_fgen_basic/error_v/error_v_wrapper.f90
+++ b/src/example_fgen_basic/error_v/error_v_wrapper.f90
@@ -1,4 +1,4 @@
-!> Wrapper for interfacing `m_error_v` with Python
+!> Wrapper for interfacing  [[m_error_v(module)::ErrorV(type)]] with Python
 !>
 !> Written by hand here.
 !> Generation to be automated in future (including docstrings of some sort).
@@ -29,7 +29,7 @@ contains
         integer, intent(in) :: code
         !! Error code
         !!
-        !! Use [TODO: figure out xref] `NO_ERROR_CODE` if there is no error
+        !> Use [[m_error_v:NO_ERROR_CODE(variable)]] if there is no error
 
         character(len=*), optional, intent(in) :: message
         !! Error message

--- a/src/example_fgen_basic/error_v/passing.f90
+++ b/src/example_fgen_basic/error_v/passing.f90
@@ -1,4 +1,4 @@
-!> Error passing
+!> *Error passing*
 !>
 !> A very basic demo to get the idea.
 !

--- a/src/example_fgen_basic/error_v/passing.py
+++ b/src/example_fgen_basic/error_v/passing.py
@@ -1,5 +1,5 @@
 """
-Wrappers of `m_error_v_passing` [TODO think about naming and x-referencing]
+Wrappers of [`m_error_v_passing`](/fortran-api/module/m_error_v_passing.html).
 
 At the moment, all written by hand.
 We will auto-generate this in future.
@@ -76,7 +76,7 @@ def pass_errors(invs: tuple[ErrorV, ...]) -> NP_ARRAY_OF_BOOL:
     """
     # Controlling memory from the Python side
     m_error_v_w.ensure_at_least_n_instances_can_be_passed_simultaneously(len(invs))
-    # TODO: consider adding `build_instances` too, might be headache
+
     instance_indexes: NP_ARRAY_OF_INT = np.array(
         [m_error_v_w.build_instance(code=inv.code, message=inv.message) for inv in invs]
     )

--- a/src/example_fgen_basic/error_v/passing_wrapper.f90
+++ b/src/example_fgen_basic/error_v/passing_wrapper.f90
@@ -26,13 +26,12 @@ module m_error_v_passing_w
 contains
 
     function pass_error(inv_instance_index) result(res)
-        !! Wrapper around `m_error_v_passing.pass_error` (TODO: x-ref)
+        !> Wrapper around `m_error_v_passing.pass_error` [[m_error_v_passing(module):pass_error(function)]].
 
         integer, intent(in) :: inv_instance_index
         !! Input values
-        !!
-        !! See docstring of `m_error_v_passing.pass_error` for details.
-        !! [TODO: x-ref]
+        !> See docstring of [[m_error_v_passing(module):pass_error(function)]] for details.
+
         !! The trick here is to pass in the instance index, not the instance itself
 
         logical :: res
@@ -48,13 +47,12 @@ contains
     end function pass_error
 
     function pass_errors(inv_instance_indexes, n) result(res)
-        !! Wrapper around `m_error_v_passing.pass_errors` (TODO: x-ref)
+        !> Wrapper around `m_error_v_passing.pass_error` [[m_error_v_passing(module):pass_errors(function)]].
 
         integer, dimension(n), intent(in) :: inv_instance_indexes
         !! Input values
         !!
-        !! See docstring of `m_error_v_passing.pass_errors` for details.
-        !! [TODO: x-ref]
+        !! See docstring of [[m_error_v_passing(module):pass_errors(function)]] for details.
 
         integer, intent(in) :: n
         !! Number of values to pass


### PR DESCRIPTION
## Description

Added cross-references both in the Fortran and Python part.
Weirdly enough some `fortran-api/module/m_error_v.html` cross references are not resolved at the time being.
## Checklist

Please confirm that this pull request has done the following:

- [ ]~Tests added~
- [ ]~Documentation added (where applicable)~ 
- [ ] Changelog item added to `changelog/`
